### PR TITLE
Add max age to defend from replay attack

### DIFF
--- a/app/services/events/invoice_payment_succeeded.rb
+++ b/app/services/events/invoice_payment_succeeded.rb
@@ -2,7 +2,20 @@ module Events
   module InvoicePaymentSucceeded
     def self.call(event, stripe_event)
       stripe_subscription_id = stripe_event.data.object.subscription
+
+      if stripe_subscription_id.nil?
+        Rails.logger.info "Invoice event #{event.stripe_id} is not connected to a subscription"
+        return
+      end
+
       subscription = Subscription.find_by_stripe_id(stripe_subscription_id)
+
+      if subscription.blank?
+        Subscription.create(stripe_id: stripe_subscription_id, events: [ event ], state: :paid)
+        Rails.logger.info "Subscription #{stripe_subscription_id} not found. Create it"
+        return
+      end
+
       subscription.pay_invoice
       subscription.events << event
       subscription.save

--- a/app/services/webhook_service.rb
+++ b/app/services/webhook_service.rb
@@ -4,9 +4,14 @@ module WebhookService
                              customer.subscription.deleted
                              invoice.payment_succeeded]
 
+  MAX_EVENT_AGE = 300 # seconds
+
   class << self
     def event_received(payload, signature)
-      stripe_event = Stripe::Webhook.construct_event(payload, signature, WEBHOOK_SECRET)
+      stripe_event = Stripe::Webhook.construct_event(
+        payload, signature, WEBHOOK_SECRET,
+        tolerance: MAX_EVENT_AGE
+      )
       Rails.logger.info "Stripe event received: #{stripe_event["type"]} #{stripe_event.id}"
 
       return if skip_processing?(stripe_event)


### PR DESCRIPTION
* Cover more cases in invoice processing: not subscription invoice handling, no unpaid subscription in database
* Add max age 5 minutes to event processing in order to defend the server from replay attack