### PR TITLE
Lock Event in order to process concurrently

### DIFF
--- a/app/jobs/event_handler_job.rb
+++ b/app/jobs/event_handler_job.rb
@@ -1,7 +1,7 @@
 class EventHandlerJob < ApplicationJob
   queue_as :default
 
-  def perform(event)
-    EventLogic.process_event(event)
+  def perform(**options)
+    EventLogic.process_event(**options)
   end
 end

--- a/db/migrate/20250113094323_remove_json_from_events.rb
+++ b/db/migrate/20250113094323_remove_json_from_events.rb
@@ -1,0 +1,5 @@
+class RemoveJsonFromEvents < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :events, :json, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_05_083347) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_13_094323) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension "pg_catalog.plpgsql"
 
   create_table "events", force: :cascade do |t|
     t.string "stripe_id", null: false
@@ -20,7 +20,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_05_083347) do
     t.string "state", default: "pending", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.jsonb "json"
     t.bigint "subscription_id"
     t.index ["stripe_id"], name: "index_events_on_stripe_id", unique: true
     t.index ["subscription_id"], name: "index_events_on_subscription_id"

--- a/spec/api/stripe/post_webhook_spec.rb
+++ b/spec/api/stripe/post_webhook_spec.rb
@@ -12,16 +12,6 @@ describe "POST /webhook", type: :request do
       end
     end
 
-    it 'creates Event' do
-      expect { post_webhook_path }.to change(Event, :count).by(1)
-      expect(Event.last).to have_attributes(
-        state: 'pending',
-        stripe_id: be,
-        stripe_type: be,
-        json: be,
-      )
-    end
-
     it 'schedule a background job' do
       expect {
         post_webhook_path
@@ -32,14 +22,6 @@ describe "POST /webhook", type: :request do
       post_webhook_path
 
       expect(response).to have_http_status(200)
-    end
-
-    context 'when event exists' do
-      let!(:event) { create :event, stripe_id: payload[:id] }
-
-      it 'does not create Event' do
-        expect { post_webhook_path }.not_to change(Event, :count)
-      end
     end
   end
 

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -6,7 +6,6 @@ FactoryBot.define do
 
     trait "customer.subscription.created" do
       stripe_type { "customer.subscription.created" }
-      json { build(:stripe_event_data, 'customer.subscription.created').to_json }
     end
 
     trait "invoice.payment_succeeded" do
@@ -15,7 +14,6 @@ FactoryBot.define do
       end
 
       stripe_type { "invoice.payment_succeeded" }
-      json { build(:stripe_event_data, 'invoice.payment_succeeded', subscription_id:).to_json }
     end
 
     trait "customer.subscription.deleted" do
@@ -24,7 +22,6 @@ FactoryBot.define do
       end
 
       stripe_type { "customer.subscription.deleted" }
-      json { build(:stripe_event_data, 'customer.subscription.deleted', subscription_id:).to_json }
     end
   end
 end

--- a/spec/factories/stripe_event.rb
+++ b/spec/factories/stripe_event.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :stripe_event, class: Stripe::Event do
+    transient do
+      data { {} }
+    end
+
+    initialize_with do
+      Stripe::Event.construct_from(data)
+    end
+  end
+end


### PR DESCRIPTION
* Use database pessimistic lock on Event in order to handle concurrent multiple processing
* In case of error event record.state is error and it can be processed again